### PR TITLE
feat: prevent repeated remote selection

### DIFF
--- a/lua/remote-line/generate.lua
+++ b/lua/remote-line/generate.lua
@@ -45,6 +45,16 @@ local function get_remote_url()
       end
     end)
   end
+
+  if vim.g.remote_line_git_remote_repository and not vim.tbl_contains(remote_list, vim.g.remote_line_git_remote_repository) then
+    error(
+      "The remote"
+      .. string.format(" `%s`", vim.g.remote_line_git_remote_repository)
+      .. " does not exist in the repository."
+      .. " Please correct the value set for `remote_line_git_remote_repository`."
+    )
+  end
+
   local remote = vim.g.remote_line_git_remote_repository or remote_list[1]
 
   local remote_url = vim.fn.system(cdDir .. "git config --get remote." .. remote .. ".url")

--- a/lua/remote-line/generate.lua
+++ b/lua/remote-line/generate.lua
@@ -36,16 +36,16 @@ local function get_remote_url()
     table.remove(remote_list, #remote_list)
   end
 
-  local remote = remote_list[1]
-  if #remote_list >= 2 then
+  if not vim.g.remote_line_git_remote_repository and #remote_list >= 2 then
     vim.ui.select(remote_list, {
       prompt = "Select remote",
     }, function(selected)
       if selected then
-        remote = selected
+        vim.g.remote_line_git_remote_repository = selected
       end
     end)
   end
+  local remote = vim.g.remote_line_git_remote_repository or remote_list[1]
 
   local remote_url = vim.fn.system(cdDir .. "git config --get remote." .. remote .. ".url")
   remote_url = vim.fn.trim(remote_url)

--- a/lua/remote-line/generate.lua
+++ b/lua/remote-line/generate.lua
@@ -46,12 +46,15 @@ local function get_remote_url()
     end)
   end
 
-  if vim.g.remote_line_git_remote_repository and not vim.tbl_contains(remote_list, vim.g.remote_line_git_remote_repository) then
+  if
+    vim.g.remote_line_git_remote_repository
+    and not vim.tbl_contains(remote_list, vim.g.remote_line_git_remote_repository)
+  then
     error(
       "The remote"
-      .. string.format(" `%s`", vim.g.remote_line_git_remote_repository)
-      .. " does not exist in the repository."
-      .. " Please correct the value set for `remote_line_git_remote_repository`."
+        .. string.format(" `%s`", vim.g.remote_line_git_remote_repository)
+        .. " does not exist in the repository."
+        .. " Please correct the value set for `remote_line_git_remote_repository`."
     )
   end
 


### PR DESCRIPTION
If the global variable `remote_line_git_remote_repository` is set, it will be used with priority. If it is not set, and there is only one remote registered, that remote will be used by default. However, if more than one remote is registered, the first selected remote will be cached in the global variable, and subsequent operations will prioritize the cached remote.