### PR TITLE
feat: add mode argument to RemoteLine command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
+          version: "v0.10.3"
 
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: leafo/gh-actions-lua@v10

--- a/lua/remote-line/generate.lua
+++ b/lua/remote-line/generate.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local function get_git_info(path)
+function M.get_git_info(path)
   local fileDir = vim.fn.expand("%:p:h")
   local cdDir = string.format("cd %s; ", fileDir)
 
@@ -125,16 +125,20 @@ local function generate_url(remote_url, action, commit, relative, firstLine, las
   return url
 end
 
-function M.url(firstLine, lastLine, path, action)
+function M.url(firstLine, lastLine, path, action, mode)
   local remote_url = get_remote_url()
 
   if not remote_url then
     return
   end
 
-  local commit, relative = get_git_info(path)
+  local commit, relative = M.get_git_info(path)
 
-  return generate_url(remote_url, action, commit, relative, firstLine, lastLine)
+  if mode == "" then
+    return generate_url(remote_url, action, commit, relative, firstLine, lastLine)
+  else
+    return generate_url(remote_url, action, mode, relative, firstLine, lastLine)
+  end
 end
 
 return M

--- a/lua/remote-line/remote.lua
+++ b/lua/remote-line/remote.lua
@@ -26,8 +26,8 @@ local function url_clipboard(url)
   end
 end
 
-function M.open(firstLine, lastLine, path, action)
-  local url = generate.url(firstLine, lastLine, path, action)
+function M.open(firstLine, lastLine, path, action, mode)
+  local url = generate.url(firstLine, lastLine, path, action, mode)
 
   if url == "" then
     return
@@ -36,8 +36,8 @@ function M.open(firstLine, lastLine, path, action)
   open_remote(url)
 end
 
-function M.copy(firstLine, lastLine, path, action)
-  local url = generate.url(firstLine, lastLine, path, action)
+function M.copy(firstLine, lastLine, path, action, mode)
+  local url = generate.url(firstLine, lastLine, path, action, mode)
 
   url_clipboard(url)
   print("success to copy the URL to clipboard")

--- a/lua/remote-line/window.lua
+++ b/lua/remote-line/window.lua
@@ -2,24 +2,24 @@ local remote = require("remote-line.remote")
 
 local M = {}
 
-local function select_option(buf, win, currentCursorLine, firstLine, path)
+local function select_option(buf, win, currentCursorLine, firstLine, path, mode)
   local row = vim.api.nvim_win_get_cursor(win)[1]
   local line = vim.api.nvim_buf_get_lines(buf, row - 1, row, false)[1]
 
   if line == "1. Open remote repository in blob" then
-    remote.open(currentCursorLine, firstLine, path, "blob")
+    remote.open(currentCursorLine, firstLine, path, "blob", mode)
   elseif line == "2. Copy remote repository URL" then
-    remote.copy(currentCursorLine, firstLine, path, "blob")
+    remote.copy(currentCursorLine, firstLine, path, "blob", mode)
   elseif line == "3. Open remote repository in blame" then
-    remote.open(currentCursorLine, firstLine, path, "blame")
+    remote.open(currentCursorLine, firstLine, path, "blame", mode)
   elseif line == "4. Open pull request the last changed commit" then
-    remote.open(currentCursorLine, firstLine, path, "pull")
+    remote.open(currentCursorLine, firstLine, path, "pull", mode)
   end
 
   vim.api.nvim_win_close(win, true)
 end
 
-function M.menu(firstLine, lastLine, path)
+function M.menu(firstLine, lastLine, path, mode)
   local content = {
     "1. Open remote repository in blob",
     "2. Copy remote repository URL",
@@ -44,7 +44,7 @@ function M.menu(firstLine, lastLine, path)
 
   vim.keymap.set("n", "q", ":q<CR>", { noremap = true, silent = true })
   vim.keymap.set("n", "<CR>", function()
-    select_option(buf, win, firstLine, lastLine, path)
+    select_option(buf, win, firstLine, lastLine, path, mode)
   end, { noremap = true, silent = true, buffer = buf })
 end
 

--- a/plugin/remote-line.lua
+++ b/plugin/remote-line.lua
@@ -3,6 +3,9 @@ if vim.g.loaded_remote_line then
 end
 vim.g.loaded_remote_line = 1
 
-vim.api.nvim_command(
-  "command! -range -nargs=0 RemoteLine lua require('remote-line.window').menu(<line1>, <line2>, vim.fn.resolve(vim.api.nvim_buf_get_name(0)))"
-)
+vim.api.nvim_create_user_command("RemoteLine", function(opts)
+  require("remote-line.window").menu(opts.line1, opts.line2, vim.fn.resolve(vim.api.nvim_buf_get_name(0)), opts.args)
+end, {
+  range = true,
+  nargs = "?",
+})

--- a/spec/generate_spec.lua
+++ b/spec/generate_spec.lua
@@ -8,22 +8,47 @@ describe("url", function()
   end)
 
   describe("when action is blob", function()
-    it("returns blob url", function()
-      local url = generate.url(1, 3, vim.fn.resolve(vim.api.nvim_buf_get_name(0)), "blob")
+    describe("when mode is blank", function()
+      it("returns blob url", function()
+        local url = generate.url(1, 3, vim.fn.resolve(vim.api.nvim_buf_get_name(0)), "blob", "")
 
-      assert.is_true(
-        string.match(url, "https://github%.com/ksaito422/remote%-line%.nvim/blob/.*/plugin/test%.lua#L1%-L3") ~= nil
-      )
+        assert.is_true(
+          string.match(url, "https://github%.com/ksaito422/remote%-line%.nvim/blob/.*/plugin/test%.lua#L1%-L3") ~= nil
+        )
+      end)
+    end)
+
+    describe("when mode is specific", function()
+      it("returns blob url", function()
+        local url = generate.url(1, 3, vim.fn.resolve(vim.api.nvim_buf_get_name(0)), "blob", "main")
+
+        assert.is_true(
+          string.match(url, "https://github%.com/ksaito422/remote%-line%.nvim/blob/main/plugin/test%.lua#L1%-L3") ~= nil
+        )
+      end)
     end)
   end)
 
   describe("when action is blame", function()
-    it("returns blame url", function()
-      local url = generate.url(1, 3, vim.fn.resolve(vim.api.nvim_buf_get_name(0)), "blame")
+    describe("when mode is blank", function()
+      it("returns blame url", function()
+        local url = generate.url(1, 3, vim.fn.resolve(vim.api.nvim_buf_get_name(0)), "blame", "")
 
-      assert.is_true(
-        string.match(url, "https://github%.com/ksaito422/remote%-line%.nvim/blame/.*/plugin/test%.lua#L1%-L3") ~= nil
-      )
+        assert.is_true(
+          string.match(url, "https://github%.com/ksaito422/remote%-line%.nvim/blame/.*/plugin/test%.lua#L1%-L3") ~= nil
+        )
+      end)
+    end)
+
+    describe("when mode is specific", function()
+      it("returns blame url", function()
+        local url = generate.url(1, 3, vim.fn.resolve(vim.api.nvim_buf_get_name(0)), "blame", "main")
+
+        assert.is_true(
+          string.match(url, "https://github%.com/ksaito422/remote%-line%.nvim/blame/main/plugin/test%.lua#L1%-L3")
+            ~= nil
+        )
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
closed #19  #16 

When tag or branch are passed as arguments, their values are used to generate the URLs. This enhancement allows for the generation of URLs for tags, branches, and commits from anywhere.

### Usage
```
RemoteLine
-> https://github.com/ksaito422/remote-line.nvim/blob/808ee5697011dab6297b8c23241f77b5c853679a/plugin/remote-line.lua#L1

RemoteLine {branch_name}
-> https://github.com/ksaito422/remote-line.nvim/blob/main/plugin/remote-line.lua#L1

RemoteLine {tag}
-> https://github.com/ksaito422/remote-line.nvim/blob/v0.1.0/plugin/remote-line.lua#L1

RemoteLine {commit_hash}
-> https://github.com/ksaito422/remote-line.nvim/blob/xxxxxxxxxxxxxxxxxxxxx/plugin/remote-line.lua#L1
```